### PR TITLE
Makefile for Mac OX X 10.8.3

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -1,0 +1,18 @@
+OBJECTS=zpaq.o libzpaq.o divsufsort.o
+
+BINARY=zpaq
+
+CXXFLAGS=-Wall -O1 -DNDEBUG -Dunix -m64 -fopenmp
+CXX=g++
+
+all: $(BINARY)
+
+$(BINARY): $(OBJECTS)
+	g++ -o $@ $^
+
+clean:
+	rm -f $(BINARY) $(OBJECTS)
+help:
+	@echo Targets are: all, clean
+
+.PHONY: all clean help


### PR DESCRIPTION
This is a Makefile that works with Mac OS X 10.8.3
-O2 oder -O3 doesn't work at all with clang!
