### PR TITLE
zpaq (latest git) segfaults with musl libc

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-zpaq715.zip, Aug. 17, 2016.
+zpaq715.zip, Aug. 17, 2016...
 
 zpaq is a journaling archiver optimized for user-level incremental
 backup of directory trees in Windows and *nix. It supports AES-256


### PR DESCRIPTION
for example on alpine linux, when compiled with gcc 6.3.0, or using a [musl-cross-make](http://github.com/richfelker/musl-cross-make) crosscompiler.
testcase: https://0x0.st/4PF.zpaq

```
Program received signal SIGSEGV, Segmentation fault.
[Switching to LWP 11033]
0x00000000004126bd in decompressThread (
    arg=<error reading variable: Cannot access memory at address 0x7ffff7fc5608>) at zpaq.cpp:2796
2796    ThreadReturn decompressThread(void* arg) {
(gdb) bt
#0  0x00000000004126bd in decompressThread (
    arg=<error reading variable: Cannot access memory at address 0x7ffff7fc5608>) at zpaq.cpp:2796
#1  0x00007ffff7dc38c0 in start (p=0x7ffff7fe0ae8)
    at src/thread/pthread_create.c:145
#2  0x00007ffff7dc5786 in __clone () at src/thread/x86_64/clone.s:21
Backtrace stopped: frame did not save the PC
```
since it crashes during pthread code, my guess would be that the application does not request a sufficient stack size for the new thread. since musl cares about system resources, it defaults to a moderate 80 KB of stack per thread. as POSIX does not give any guarantuees about default stack size, a portable application **must** request a sufficient stacksize using `pthread_attr_setstacksize()` before calling `pthread_create()`.
see this as reference for a similar problem encountered in SDL: https://bugzilla.libsdl.org/show_bug.cgi?id=2019

notice that i opened a pull request instead of an issue, because you didnt open an issue tracker here (it's one click in the repo settings to enable it).
so you can happily ignore the change that is associated with the PR.
