### PR TITLE
Update libzpaq.cpp

### DIFF
--- a/libzpaq.cpp
+++ b/libzpaq.cpp
@@ -27,6 +27,7 @@ See libzpaq.h for additional documentation.
 #include <string>
 #include <vector>
 #include <stdio.h>
+#include <iostream>
 
 #ifdef unix
 #ifndef NOJIT
@@ -56,6 +57,13 @@ void Writer::write(const char* buf, int n) {
   for (int i=0; i<n; ++i)
     put(U8(buf[i]));
 }
+
+  /*
+void error(const char* msg) //Uncomment this block if getting error of undefined reference to "error"
+{
+    std::clog<<"libzpaq error: " << msg << std::endl;
+}
+*/
 
 ///////////////////////// allocx //////////////////////
 


### PR DESCRIPTION
When I compiled using just libzpaq.h and libzpaq.cpp I was getting an error. I haven't checked if the function is defined elsewhere in the repository, so to prevent breaks of future code, I block commented it out. If someone else is just using the .h/.cpp files, then it is best to uncomment this block, and either redefine the function or leave it as is.